### PR TITLE
Attach the created security list to the subnet

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -83,6 +83,7 @@ resource "oci_core_subnet" "wideo_bot" {
   compartment_id = oci_identity_compartment.wideo_bot.id
   vcn_id         = oci_core_vcn.wideo_bot.id
   route_table_id = oci_core_route_table.wideo_bot.id
+  security_list_ids = [oci_core_security_list.wideo_bot.id]
 }
 
 resource "oci_core_security_list" "wideo_bot" {


### PR DESCRIPTION
### Issue:
If you browse the Oracle Cloud console, you will see that by default, the default security list is attached to the `oci_core_subnet.wideo_bot`. This means that the security list created in this terraform code, `oci_core_security_list.wideo_bot` is not attached to the `oci_core_subnet.wideo_bot`. Any changes you make to the security rules for `oci_core_security_list.wideo_bot` will not propagate to the subnet.

### Testing the fix:
Browse to the oracle cloud console webgui before and after this change to see what security list is attached to the subnet. Or alternatively, temporarily adding a security rule for permitting ping, and ensuring that you can ping the instance:
```
ingress_security_rules {
  source_type = "CIDR_BLOCK"
  protocol    = "1"
  source      = "0.0.0.0/0"
  icmp_options {
    type = 8
    code = 0
  }
}
```

Example can be found: https://docs.oracle.com/en-us/iaas/developer-tutorials/tutorials/tf-vcn/01-summary.htm in Section 3. Customize the network [Create a private/public subnet]